### PR TITLE
Change rack pieces

### DIFF
--- a/src/GameBoard/CharacterRack.tsx
+++ b/src/GameBoard/CharacterRack.tsx
@@ -1,26 +1,83 @@
+import { useState } from 'react';
 import DebugButton from '../components/DebugButton';
 import { fillRack } from '../features/game/gameSlice';
 import { useAppDispatch, useAppSelector } from '../hooks/state-hooks';
 import CharacterRackPiece from './CharacterRackPiece';
+import { BoardSquarePiece } from '../utils/types';
+
+/*
+Ideas for swapping selection: 
+- hightlight by animated pulsing
+- highlight by a caret on top of the selection.
+- animate the transition
+- only update the redux state when the user confirms the swap
+*/
 
 export default function CharacterRack() {
   const rackPieces = useAppSelector((state) => state.game.rack.pieces);
   // const sackPieces = useAppSelector((state) => state.sack.piecesByIds);
   const dispatch = useAppDispatch();
+
+  const [isChoosingPiecesToSwap, setIsChoosingPiecesToSwap] = useState(false);
+  const [chosenPieces, setChosenPieces] = useState<BoardSquarePiece[]>([]);
+
   function handleFillRack() {
     dispatch(fillRack());
   }
 
+  function handleInitiatePieceSwap() {
+    setIsChoosingPiecesToSwap(true);
+  }
+
+  function handleFinishPieceSwap() {
+    setIsChoosingPiecesToSwap(false);
+    console.log(`You wish to swap the following pieces: ${chosenPieces.map((p) => p.value).join(', ')}`);
+    setChosenPieces([]);
+  }
+
+  function createPieceSelectionToggler(piece: BoardSquarePiece) {
+    const togglerFn = () => {
+      setChosenPieces((prev) => {
+        if (prev.includes(piece)) {
+          return prev.filter((p) => p !== piece);
+        }
+        return prev.concat(piece);
+      });
+    };
+    return togglerFn;
+  }
+
   return (
     <>
-      <DebugButton handleClick={handleFillRack} type="danger">
-        TEST: fill rack with something
-      </DebugButton>
+      <div className="flex flex-col lg:flex-row mx-[-100px]">
+        <DebugButton handleClick={handleFillRack}>TEST: fill rack with something</DebugButton>
 
-      <ul className="flex flex-wrap justify-center gap-2 bg-slate-400 py-2 rounded-md shadow-sm min-h-[40px]">
-        {rackPieces.map((character, idx) => (
+        {isChoosingPiecesToSwap ? (
+          <DebugButton handleClick={handleFinishPieceSwap} type="success">
+            Confirm Swap Selection
+          </DebugButton>
+        ) : (
+          <DebugButton handleClick={handleInitiatePieceSwap} type="neutral">
+            Initiate operation{' '}
+            <span className="font-serif text-gray-200 underline underline-offset-2 decoration-wavy">piece swap</span>
+          </DebugButton>
+        )}
+      </div>
+
+      <ul
+        className="flex flex-wrap justify-center gap-2 bg-slate-400 py-2 rounded-md shadow-sm min-h-[40px]"
+        style={{
+          border: isChoosingPiecesToSwap ? '8px solid white' : '',
+        }}
+      >
+        {rackPieces.map((piece, idx) => (
           <li key={idx}>
-            <CharacterRackPiece character={character.value ?? ''} />
+            <CharacterRackPiece
+              character={piece.value ?? ''}
+              toggleSelection={createPieceSelectionToggler(piece)}
+              isChosen={chosenPieces.includes(piece)}
+              isChoosingPiecesToSwap={isChoosingPiecesToSwap}
+            />
           </li>
         ))}
       </ul>

--- a/src/GameBoard/CharacterRack.tsx
+++ b/src/GameBoard/CharacterRack.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import DebugButton from '../components/DebugButton';
-import { fillRack } from '../features/game/gameSlice';
+import { fillRack, replaceRackPieces } from '../features/game/gameSlice';
 import { useAppDispatch, useAppSelector } from '../hooks/state-hooks';
 import CharacterRackPiece from './CharacterRackPiece';
 import { BoardSquarePiece } from '../utils/types';
@@ -32,6 +32,14 @@ export default function CharacterRack() {
   function handleFinishPieceSwap() {
     setIsChoosingPiecesToSwap(false);
     console.log(`You wish to swap the following pieces: ${chosenPieces.map((p) => p.value).join(', ')}`);
+
+    // The action could already use the piece values
+    dispatch(
+      replaceRackPieces({
+        pieces: chosenPieces,
+      }),
+    );
+
     setChosenPieces([]);
   }
 

--- a/src/GameBoard/CharacterRackPiece.tsx
+++ b/src/GameBoard/CharacterRackPiece.tsx
@@ -1,14 +1,37 @@
 interface CharacterHandPieceProps {
   character: string;
+  toggleSelection: () => void;
+  isChosen: boolean;
+  isChoosingPiecesToSwap: boolean;
 }
 
-export default function CharacterRackPiece({ character }: CharacterHandPieceProps) {
+export default function CharacterRackPiece({
+  character,
+  toggleSelection,
+  isChosen,
+  isChoosingPiecesToSwap,
+}: CharacterHandPieceProps) {
+  if (isChoosingPiecesToSwap) {
+    return (
+      <button
+        className="border-2 border-black
+   w-[40px] h-[40px] flex justify-center items-center bg-slate-300 text-black text-xl font-semibold shadow-lg"
+        style={{
+          backgroundColor: isChosen ? 'blue' : 'rgb(203,213,225)',
+          color: isChosen ? 'white' : 'black',
+        }}
+        onClick={toggleSelection}
+      >
+        {character}
+      </button>
+    );
+  }
   return (
-    <div
+    <button
       className="border-2 border-black
      w-[40px] h-[40px] flex justify-center items-center bg-slate-300 text-black text-xl font-semibold shadow-lg"
     >
       {character}
-    </div>
+    </button>
   );
 }

--- a/src/components/DebugButton.tsx
+++ b/src/components/DebugButton.tsx
@@ -9,13 +9,13 @@ interface DebugButtonProps {
 
 const colorsByType = {
   danger: '#77002f',
-  success: '#01ad1d',
+  success: '#006511',
   neutral: '#aa19b0',
 };
 
 const lightColorsByType = {
-  danger: '#ff086b',
-  success: '#37fe57',
+  danger: '#ae0046',
+  success: '#007213',
   neutral: '#e25de8',
 };
 

--- a/src/features/game/gameSlice.ts
+++ b/src/features/game/gameSlice.ts
@@ -149,11 +149,48 @@ export const gameSlice = createSlice({
         state.sack.piecesByIds[id] = toAdd;
       });
     },
+    replaceRackPieces: (state, action: PayloadAction<{ pieces: BoardSquarePiece[] }>) => {
+      const { pieces } = action.payload;
+      const nofToReplace = pieces.length;
+      const piecesByIds = state.sack.piecesByIds;
+      if (Object.values(piecesByIds).length < pieces.length) {
+        throw new Error('Not enough pieces in sack');
+      }
+
+      // Remove from rack
+
+      const pieceIds = pieces.map((p) => p.id);
+      state.rack.pieces = state.rack.pieces.filter((p) => !pieceIds.includes(p.id));
+
+      // Add to rack
+      // SHould there be a global map to find a piece by id?
+      const newPieceIds = getRandomElements(Object.keys(piecesByIds), nofToReplace);
+      const newPieces = newPieceIds.map((id) => piecesByIds[id]);
+
+      state.rack.pieces.push(...newPieces);
+
+      // Remove from sack
+
+      newPieceIds.forEach((id) => delete piecesByIds[id]);
+
+      // Add old pieces to the sack!!
+      pieces.forEach((piece) => {
+        piecesByIds[piece.id] = piece;
+      });
+    },
   },
   selectors: {},
 });
 
-export const { reset, writeBoardValue, addToRack, addToSack, fillRack, removeFromRack, removeFromSack } =
-  gameSlice.actions;
+export const {
+  reset,
+  writeBoardValue,
+  addToRack,
+  addToSack,
+  fillRack,
+  removeFromRack,
+  removeFromSack,
+  replaceRackPieces,
+} = gameSlice.actions;
 
 export default gameSlice.reducer;

--- a/src/features/game/gameSlice.ts
+++ b/src/features/game/gameSlice.ts
@@ -153,24 +153,28 @@ export const gameSlice = createSlice({
       const { pieces } = action.payload;
       const nofToReplace = pieces.length;
       const piecesByIds = state.sack.piecesByIds;
+
+      // This should not be called every time
+      const allPieceInfo = getAllPlayingPieces();
+
+      const pieceIndexesInRack = pieces.map((p) => p.id).map((id) => state.rack.pieces.map((p) => p.id).indexOf(id));
+
       if (Object.values(piecesByIds).length < pieces.length) {
         throw new Error('Not enough pieces in sack');
       }
 
-      // Remove from rack
-
-      const pieceIds = pieces.map((p) => p.id);
-      state.rack.pieces = state.rack.pieces.filter((p) => !pieceIds.includes(p.id));
-
       // Add to rack
       // SHould there be a global map to find a piece by id?
       const newPieceIds = getRandomElements(Object.keys(piecesByIds), nofToReplace);
-      const newPieces = newPieceIds.map((id) => piecesByIds[id]);
+      const newPieces = newPieceIds.map((id) => allPieceInfo.find((p) => p.id === id) as BoardSquarePiece);
 
-      state.rack.pieces.push(...newPieces);
+      for (let i = 0; i < nofToReplace; i++) {
+        const pieceToPlace = newPieces[i];
+        // Here I assign multiple things...
+        state.rack.pieces[pieceIndexesInRack[i]] = pieceToPlace;
+      }
 
       // Remove from sack
-
       newPieceIds.forEach((id) => delete piecesByIds[id]);
 
       // Add old pieces to the sack!!


### PR DESCRIPTION
Change rack pieces with the sack. Easier option to implement than writing a word on the board.

Combined the gameplay state into one reducer. This was the most straightforward way I thought of to handle actions that have consequences on rack, sack and board.